### PR TITLE
Change terminal name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ const commands: Record<string, (...args: any[]) => any> = {
 
       terminal = vscode.window.createTerminal({
         isTransient: true,
-        name: "IEx",
+        name: "beam.smp",
         shellPath: process.env.SHELL,
         cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
       });


### PR DESCRIPTION
The default terminal name when you start a teminal manually is "beam.smp". I find it more convenient when using this plugin to start my session manually. 

Up to you to decide if it fit your workflow.

And thank you for this very usefull plugin